### PR TITLE
Tests for `CableReady::Identifiable` and `CableReady::OperationBuilder`

### DIFF
--- a/lib/cable_ready/identifiable.rb
+++ b/lib/cable_ready/identifiable.rb
@@ -16,7 +16,7 @@ module CableReady
         [prefix, record.to_s.strip].compact.join("_")
       end
 
-      "##{id}".squeeze('#').strip
+      "##{id}".squeeze("#").strip
     end
   end
 end

--- a/lib/cable_ready/identifiable.rb
+++ b/lib/cable_ready/identifiable.rb
@@ -1,16 +1,22 @@
 # frozen_string_literal: true
 
+require "active_record"
+require "action_view"
+
 module CableReady
   module Identifiable
-    def dom_id(record, prefix = nil, hash: "#")
+    def dom_id(record, prefix = nil)
+      prefix = prefix.to_s.strip if prefix
+
       id = if record.is_a?(ActiveRecord::Relation)
         [prefix, record.model_name.plural].compact.join("_")
       elsif record.is_a?(ActiveRecord::Base)
-        ActionView::RecordIdentifier.dom_id(record, prefix).to_s
+        ActionView::RecordIdentifier.dom_id(record, prefix)
       else
-        [prefix, record.to_s].compact.join("_")
+        [prefix, record.to_s.strip].compact.join("_")
       end
-      (hash + id).squeeze("#")
+
+      "##{id}".squeeze('#').strip
     end
   end
 end

--- a/lib/cable_ready/operation_builder.rb
+++ b/lib/cable_ready/operation_builder.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_record"
+
 require_relative "identifiable"
 
 module CableReady

--- a/test/lib/cable_ready/identifiable_test.rb
+++ b/test/lib/cable_ready/identifiable_test.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require_relative "../../../lib/cable_ready"
+
+class User
+  include ActiveModel::Model
+
+  attr_accessor :id
+end
+
+class CableReady::IdentifiableTest < ActiveSupport::TestCase
+  include CableReady::Identifiable
+
+  test "should handle nil" do
+    assert_equal "#", dom_id(nil)
+  end
+
+  test "should work with strings" do
+    assert_equal "#users", dom_id("users")
+    assert_equal "#users", dom_id("users  ")
+    assert_equal "#users", dom_id("  users  ")
+  end
+
+  test "should work with symbols" do
+    assert_equal "#users", dom_id(:users)
+    assert_equal "#active_users", dom_id(:active_users)
+  end
+
+  test "should just return one hash" do
+    assert_equal "#users", dom_id("users")
+    assert_equal "#users", dom_id("#users")
+    assert_equal "#users", dom_id("##users")
+  end
+
+  test "should strip prefixes" do
+    assert_equal "#active_users", dom_id("  users ", "     active    ")
+    assert_equal "#all_active_users", dom_id(" users  ", "  all_active ")
+  end
+
+  test "should not include provided prefix if prefix is nil" do
+    assert_equal "#users", dom_id("users", nil)
+  end
+
+  test "should work with ActiveRecord::Relation" do
+    relation = mock("ActiveRecord::Relation")
+
+    relation.stubs(:is_a?).with(ActiveRecord::Relation).returns(true).at_least_once
+    relation.stubs(:is_a?).with(ActiveRecord::Base).never
+    relation.stubs(:model_name).returns(OpenStruct.new(plural: "users"))
+
+    assert_equal "#users", dom_id(relation)
+    assert_equal "#users", dom_id(relation, nil)
+    assert_equal "#active_users", dom_id(relation, "active")
+  end
+
+  test "should work with ActiveRecord::Base" do
+    User.any_instance.stubs(:is_a?).with(ActiveRecord::Relation).returns(false)
+    User.any_instance.stubs(:is_a?).with(ActiveRecord::Base).returns(true)
+
+    assert_equal "#new_user", dom_id(User.new(id: nil))
+
+    user = User.new(id: 42)
+
+    assert_equal "#user_42", dom_id(user)
+    assert_equal "#user_42", dom_id(user, nil)
+    assert_equal "#all_active_user_42", dom_id(user, "all_active")
+
+    user = User.new(id: 99)
+
+    assert_equal "#user_99", dom_id(user)
+    assert_equal "#user_99", dom_id(user, nil)
+    assert_equal "#all_active_user_99", dom_id(user, "all_active")
+  end
+end


### PR DESCRIPTION
Here is a proposal to further improve the awesome PR hopsoft/cable_ready#107.

This PR adds:
*  ~~a new `CableReady::OperationBuilder#selector` method~~

    ~~This method can be useful to explicit define which selector should be used. Previously the `previous_selector` was just set implicitly if you called another operation before. With `#selector` you can explicitly control the selector.~~

* ~~tests for the above mentioned `CableReady::OperationBuilder#selector `~~
* more tests for `CableReady::OperationBuilder` 
* a small refactoring for `CableReady::Identifiable`
* a ton of tests for `CableReady::Identifiable`
 